### PR TITLE
feat: used semantic-release/exec to clean changelog headings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+      - run: cat CHANGELOG.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,6 +10,12 @@
 				"changelogTitle": "# Changelog"
 			}
 		],
+		[
+			"@semantic-release/exec",
+			{
+				"prepare": "echo hello world"
+			}
+		],
 		"@semantic-release/github",
 		"@semantic-release/npm",
 		[

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,7 @@
 		[
 			"@semantic-release/exec",
 			{
-				"prepare": "echo hello world"
+				"prepare": "sed -i 's/# \\[/## \\[/g' CHANGELOG.md"
 			}
 		],
 		"@semantic-release/github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Changelog
 
-# [1.6.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.5.0...v1.6.0) (2022-12-13)
+## [1.6.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.5.0...v1.6.0) (2022-12-13)
 
 ### Features
 
 - change GHANGELOG.md title to include hash ([297eb4e](https://github.com/JoshuaKGoldberg/template-typescript-package/commit/297eb4edf9187d7f38d03e3be2daf169f05fe8a4))
 
-# [1.5.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.4.0...v1.5.0) (2022-12-13)
+## [1.5.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.4.0...v1.5.0) (2022-12-13)
 
 ### Features
 
 - add test entry to CHANGELOG.md ([c39b3db](https://github.com/JoshuaKGoldberg/template-typescript-package/commit/c39b3db1ad2bf8cd9eb2939ac1d3bba848a2f3d5))
 
-# [1.4.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.3.0...v1.4.0) (2022-12-13)
+## [1.4.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.3.0...v1.4.0) (2022-12-13)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 ## [1.6.0](https://github.com/JoshuaKGoldberg/template-typescript-package/compare/v1.5.0...v1.6.0) (2022-12-13)

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
 	"dictionaries": ["typescript"],
 	"ignorePaths": [
 		".github",
+		"CHANGELOG.md",
 		"lib",
 		"node_modules",
 		"pnpm-lock.yaml",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"devDependencies": {
 		"@semantic-release/changelog": "^6.0.1",
 		"@semantic-release/commit-analyzer": "^9.0.2",
+		"@semantic-release/exec": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
 		"@semantic-release/github": "^8.0.6",
 		"@semantic-release/npm": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@semantic-release/changelog': ^6.0.1
   '@semantic-release/commit-analyzer': ^9.0.2
+  '@semantic-release/exec': ^6.0.3
   '@semantic-release/git': ^10.0.1
   '@semantic-release/github': ^8.0.6
   '@semantic-release/npm': ^9.0.1
@@ -40,6 +41,7 @@ specifiers:
 devDependencies:
   '@semantic-release/changelog': 6.0.2_semantic-release@19.0.5
   '@semantic-release/commit-analyzer': 9.0.2_semantic-release@19.0.5
+  '@semantic-release/exec': 6.0.3_semantic-release@19.0.5
   '@semantic-release/git': 10.0.1_semantic-release@19.0.5
   '@semantic-release/github': 8.0.7_semantic-release@19.0.5
   '@semantic-release/npm': 9.0.1_semantic-release@19.0.5
@@ -976,6 +978,23 @@ packages:
   /@semantic-release/error/3.0.0:
     resolution: {integrity: sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==}
     engines: {node: '>=14.17'}
+    dev: true
+
+  /@semantic-release/exec/6.0.3_semantic-release@19.0.5:
+    resolution: {integrity: sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==}
+    engines: {node: '>=14.17'}
+    peerDependencies:
+      semantic-release: '>=18.0.0'
+    dependencies:
+      '@semantic-release/error': 3.0.0
+      aggregate-error: 3.1.0
+      debug: 4.3.4
+      execa: 5.1.1
+      lodash: 4.17.21
+      parse-json: 5.2.0
+      semantic-release: 19.0.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@semantic-release/git/10.0.1_semantic-release@19.0.5:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #107
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Pending https://github.com/semantic-release/changelog/issues/279 having a resolution, this uses a manual script to swap out `\n# ` for `\n## ` in `CHANGELOG.md`.